### PR TITLE
Add dozzle docker-compose; logs monitoring tool

### DIFF
--- a/monitoring/dozzle/docker-compose.yml
+++ b/monitoring/dozzle/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  dozzle:
+    container_name: dozzle
+    image: amir20/dozzle:latest
+    volumes:
+      - /run/user/1000/docker.sock:/var/run/docker.sock
+    ports:
+      - 8084:8080
+    environment:
+      - DEBUG=15s


### PR DESCRIPTION
Needs to be set up completely independently and monitors all docker containers on the host
closes #49 