### PR TITLE
feat: disable post for user command added

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -7,7 +7,7 @@ from telegram.ext import ApplicationBuilder, MessageHandler, CommandHandler
 from src.message_handlers import message_handler
 from src.command_handlers import (
     start_command, disable_command, list_all_active_sales, list_all_active_searches, list_my_active_posts,
-    add_bgg_username, disable_user, import_my_bgg_collection, match_me
+    add_bgg_username, disable_user, import_my_bgg_collection, match_me, disable_post_for_user
 )
 from src.models import db
 from src.database import init_tables
@@ -32,6 +32,7 @@ def init_app(auth_token):
     app.add_handler(CommandHandler("list_my_posts", list_my_active_posts))
     app.add_handler(CommandHandler("add_bgg_username", add_bgg_username))
     app.add_handler(CommandHandler("disable_user", disable_user))
+    app.add_handler(CommandHandler("disable_post_for_user", disable_post_for_user))
     app.add_handler(CommandHandler("import_my_bgg_collection", import_my_bgg_collection))
     app.add_handler(CommandHandler("match_me", match_me))
 

--- a/src/command_handlers.py
+++ b/src/command_handlers.py
@@ -16,7 +16,8 @@ from src.messages import (
     INVALID_DISABLE_USER,
     INVALID_ADD_BGG_USERNAME_ERROR,
     INVALID_ADD_BGG_USERNAME_NOT_FOUND,
-    INVALID_ADD_BGG_USERNAME_SHOW_FORMAT
+    INVALID_ADD_BGG_USERNAME_SHOW_FORMAT,
+    MEEPLE_MATCHMAKER_START
     )
 log = logging.getLogger("meeple-matchmaker")
 
@@ -24,7 +25,6 @@ admin_ids = [
     995823071, # Sahil Thapar
     6946013582, # Mica
     635786234, # Anshul J
-    1294547458
 ]
 
 def format_post(post: Post, bgg_client: BGGClient) -> str:
@@ -87,25 +87,7 @@ async def start_command(update, _):
     :param _:
     :return:
     """
-    reply = """
-Hi! I'm Meeple Matchmaker Bot.
-
-I help match buyers and sellers in the Meeple Market Telegram channel.
-
-*How to use:*
-- Start your message with a hashtag and the game name (as listed on BGG).
-  - To buy: #lookingfor, #iso, #looking
-  - To sell: #sale, #sell, #selling, #auction (Not allowed in DMs)
-- The bot will check the game name on BGG and react with 👍 if it finds a match.
-
-*Tip:*
-Keep the first line to just the hashtag and game name. Add details (condition, price, location) on new lines.
-
-[Full guide & features](https://github.com/sahilthapar/meeple-matchmaker/blob/main/README.md)
-[FAQ](https://github.com/sahilthapar/meeple-matchmaker/blob/main/faq.md)
-Suggestions? Use the chit chat group or [GitHub issues](https://github.com/sahilthapar/meeple-matchmaker/issues).
-**Don't post suggestions in the main channel.**
-"""
+    reply = MEEPLE_MATCHMAKER_START
     if update.effective_chat.type != "private":
         await update.message.set_reaction("👎")
     else:

--- a/src/command_handlers.py
+++ b/src/command_handlers.py
@@ -1,4 +1,5 @@
 """Handler for telegram bot commands"""
+import re
 import textwrap
 import logging
 import os
@@ -9,13 +10,20 @@ from boardgamegeek.objects.games import CollectionBoardGame
 from src.models import Post, UserCollection, Game
 from src.telegrampost import create_user_from_message, get_message_without_command
 from src.database import disable_posts, read_posts
-
+from src.messages import (INVALID_DISABLE_POST_FOR_USER, 
+                          INVALID_NOT_AN_ADMIN, 
+                          INVALID_DISABLE_USER, 
+                          INVALID_ADD_BGG_USERNAME_ERROR, 
+                          INVALID_ADD_BGG_USERNAME_NOT_FOUND, 
+                          INVALID_ADD_BGG_USERNAME_SHOW_FORMAT
+                          )
 log = logging.getLogger("meeple-matchmaker")
 
 admin_ids = [
     995823071, # Sahil Thapar
     6946013582, # Mica
     635786234, # Anshul J
+    1294547458
 ]
 
 def format_post(post: Post, bgg_client: BGGClient) -> str:
@@ -180,12 +188,8 @@ async def add_bgg_username(update, _):
             user.save()
             await update.message.set_reaction("👍")
         except IndexError:
-            await update.message.reply_text(
-                "Invalid username! Add username after the command. Copy the example below."
-            )
-            await update.message.reply_text(
-                "/add_bgg_username my-username"
-            )
+            await update.message.reply_text(INVALID_ADD_BGG_USERNAME_ERROR)
+            await update.message.reply_text(INVALID_ADD_BGG_USERNAME_SHOW_FORMAT)
             await update.message.set_reaction("👎")
 
 
@@ -217,9 +221,7 @@ async def import_my_bgg_collection(update, _):
         await update.message.set_reaction("👎")
     else:
         if not user.bgg_username:
-            await update.message.reply_text(
-                "No BGG username found! Please attach a BGG User using the command /add_bgg_username <your-username>"
-            )
+            await update.message.reply_text(INVALID_ADD_BGG_USERNAME_NOT_FOUND)
             await update.message.set_reaction("👎")
 
             raise KeyError("No BGG username found! Please attach a BGG User")
@@ -306,12 +308,43 @@ async def disable_user(update, _):
         return
 
     if update.message.from_user.id not in admin_ids:
-        await update.message.reply_text("Sorry this command is only available to the admin!")
+        await update.message.reply_text(INVALID_NOT_AN_ADMIN)
         return
     try:
-        user_to_disable = get_message_without_command(update.message)
+        pattern = r"(?:\/disable_user)\s+(\d+)\s+(sale|search|all)$"
+        match = re.match(pattern, update.message.text)
+        if match is None or len(match.groups()) < 2:
+            raise IndexError
+        user_id, post_type = match.groups()
+        # set post type to None if admin chooses all, so that the db disables all the post types for that user
+        post_type = None if post_type == "all" else post_type
+        disable_posts(user_id, post_type)
     except IndexError:
-        await update.message.reply_text("Please enter a user id")
+        await update.message.reply_text(INVALID_DISABLE_USER)
         return
-    disable_posts(user_id=int(user_to_disable))
     await update.message.set_reaction("👍")
+
+async def disable_post_for_user(update, _):
+    """
+    Takes in a request to disable a specific post for a user
+    Must be requested by an admin only
+    """
+    if update.effective_chat.type != "private":
+        await update.message.set_reaction("👎")
+        return
+    if update.message.from_user.id not in admin_ids:
+        await update.message.reply_text(INVALID_NOT_AN_ADMIN)
+        return
+    try:
+        message_contents = update.message.text
+        # Captures a number, a space separated string for game name, and post type as sale or search
+        # pattern = r"(?:\/disable_post_for_user)\s+(\d+)\s+(.+?)\s+(sale|search)$"
+        pattern = r"(?:\/disable_post_for_user)\s+(\d+)\s+(\d+)\s+(sale|search)$"
+        match = re.match(pattern, message_contents)
+        if match is None or len(match.groups()) < 3:
+            raise IndexError
+        user_id, game_id, post_type = match.groups()
+        disable_posts(user_id, post_type, game_id)
+        await update.message.set_reaction("👍")
+    except IndexError:
+        await update.message.reply_text(INVALID_DISABLE_POST_FOR_USER)

--- a/src/command_handlers.py
+++ b/src/command_handlers.py
@@ -10,13 +10,14 @@ from boardgamegeek.objects.games import CollectionBoardGame
 from src.models import Post, UserCollection, Game
 from src.telegrampost import create_user_from_message, get_message_without_command
 from src.database import disable_posts, read_posts
-from src.messages import (INVALID_DISABLE_POST_FOR_USER, 
-                          INVALID_NOT_AN_ADMIN, 
-                          INVALID_DISABLE_USER, 
-                          INVALID_ADD_BGG_USERNAME_ERROR, 
-                          INVALID_ADD_BGG_USERNAME_NOT_FOUND, 
-                          INVALID_ADD_BGG_USERNAME_SHOW_FORMAT
-                          )
+from src.messages import (
+    INVALID_DISABLE_POST_FOR_USER,
+    INVALID_NOT_AN_ADMIN,
+    INVALID_DISABLE_USER,
+    INVALID_ADD_BGG_USERNAME_ERROR,
+    INVALID_ADD_BGG_USERNAME_NOT_FOUND,
+    INVALID_ADD_BGG_USERNAME_SHOW_FORMAT
+    )
 log = logging.getLogger("meeple-matchmaker")
 
 admin_ids = [

--- a/src/messages.py
+++ b/src/messages.py
@@ -1,0 +1,10 @@
+"""Contains message constants for use across the project"""
+
+
+# Command handler messages
+INVALID_DISABLE_POST_FOR_USER = "Please follow this format:\n /disable_post_for_user <user_id> <game_id> (sale|search)"
+INVALID_DISABLE_USER = "Please enter a valid user id and post type"
+INVALID_NOT_AN_ADMIN = "Sorry this command is only available to the admin!"
+INVALID_ADD_BGG_USERNAME_ERROR = "Invalid username! Add username after the command. Copy the example below."
+INVALID_ADD_BGG_USERNAME_NOT_FOUND = "No BGG username found! Please attach a BGG User using the command /add_bgg_username <your-username>"
+INVALID_ADD_BGG_USERNAME_SHOW_FORMAT = "/add_bgg_username my-username"

--- a/src/messages.py
+++ b/src/messages.py
@@ -3,8 +3,27 @@
 
 # Command handler messages
 INVALID_DISABLE_POST_FOR_USER = "Please follow this format:\n /disable_post_for_user <user_id> <game_id> (sale|search)"
-INVALID_DISABLE_USER = "Please enter a valid user id and post type"
+INVALID_DISABLE_USER = "Please enter a valid user id and post type (sale|search|all)"
 INVALID_NOT_AN_ADMIN = "Sorry this command is only available to the admin!"
 INVALID_ADD_BGG_USERNAME_ERROR = "Invalid username! Add username after the command. Copy the example below."
 INVALID_ADD_BGG_USERNAME_NOT_FOUND = "No BGG username found! Please attach a BGG User using the command /add_bgg_username <your-username>"
 INVALID_ADD_BGG_USERNAME_SHOW_FORMAT = "/add_bgg_username my-username"
+MEEPLE_MATCHMAKER_START = """
+Hi! I'm Meeple Matchmaker Bot.
+
+I help match buyers and sellers in the Meeple Market Telegram channel.
+
+*How to use:*
+- Start your message with a hashtag and the game name (as listed on BGG).
+  - To buy: #lookingfor, #iso, #looking
+  - To sell: #sale, #sell, #selling, #auction (Not allowed in DMs)
+- The bot will check the game name on BGG and react with 👍 if it finds a match.
+
+*Tip:*
+Keep the first line to just the hashtag and game name. Add details (condition, price, location) on new lines.
+
+[Full guide & features](https://github.com/sahilthapar/meeple-matchmaker/blob/main/README.md)
+[FAQ](https://github.com/sahilthapar/meeple-matchmaker/blob/main/faq.md)
+Suggestions? Use the chit chat group or [GitHub issues](https://github.com/sahilthapar/meeple-matchmaker/issues).
+**Don't post suggestions in the main channel.**
+"""

--- a/tests/test_command_handlers.py
+++ b/tests/test_command_handlers.py
@@ -14,7 +14,14 @@ from src.command_handlers import (
      add_bgg_username,
      get_status_from_bgg_game,
      match_me,
-     disable_user)
+     disable_user,
+     disable_post_for_user
+     )
+from src.messages import (
+    INVALID_DISABLE_POST_FOR_USER,
+    INVALID_NOT_AN_ADMIN,
+    INVALID_DISABLE_USER,
+    )
 from tests.helpers import initialize_post
 
 class TestCommandHandlers:
@@ -389,44 +396,194 @@ class TestCommandHandlers:
         expected_calls = [call(op, parse_mode="Markdown") for op in expected_output]
         mock_update.message.reply_text.assert_has_calls(expected_calls)
 
-    @pytest.mark.parametrize(["update_details","user_to_disable"],
+    @pytest.mark.parametrize(["update_details","user_to_disable", "post_type"],
                             [
                                 (
-                                    {"chat_type":"group", "user_id":"101", "text":"/disable_user 101"},
-                                    "101"
+                                    {
+                                        "chat_type":"group", 
+                                        "user_id":"101",
+                                        "text":"/disable_user 101 sale"
+                                    },
+                                    "101",
+                                    "sale"
                                 ),
                                 (
-                                    {"chat_type":"private", "user_id":"102", "text":"/disable_user"},
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"102",
+                                        "text":"/disable_user"
+                                    },
+                                    None,
                                     None
                                 ),
                                 (
-                                    {"chat_type":"private", "user_id":"103", "text":"/disable_user 101"},
-                                    "101"
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"103",
+                                        "text":"/disable_user 101 sale"
+                                    },
+                                    "101",
+                                    "sale"
                                 ),
                                 (
-                                    {"chat_type":"private", "user_id":"101", "text":"/disable_user 101"},
-                                    "101"
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"103",
+                                        "text":"/disable_user 101 search"
+                                    },
+                                    "101",
+                                    "search"
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"103",
+                                        "text":"/disable_user 101 all"
+                                    },
+                                    "101",
+                                    # when post type is all, we pass post_type=None to disable_posts so it handles all posts
+                                    None
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"103",
+                                        "text":"/disable_user 101 gibberish"
+                                    },
+                                    "101",
+                                    "gibberish"
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"101",
+                                        "text":"/disable_user 101 sale"
+                                    },
+                                    "101",
+                                    "sale"
                                 )
                             ],
-                            ids=["failed_in_group", "invalid_message_format", "successfully_disabled", "non-admin"]
+                            ids=[
+                                "failed_in_group",
+                                "invalid_message_format",
+                                "successfully_disabled_sale",
+                                "successfully_disabled_search",
+                                "successfully_disabled_all",
+                                "invalid_post_type",
+                                 "non-admin"
+                                 ]
                             )
-    async def test_disable_user(self, mock_update, update_details, mocker, user_to_disable):
+    async def test_disable_user(self, mock_update, update_details, mocker, user_to_disable, post_type):
         mock_update.effective_chat.type=update_details["chat_type"]
         mock_update.message.from_user.id=update_details["user_id"]
         mock_update.message.text=update_details["text"]
-        
+
         mock_disable_posts = mocker.patch("src.command_handlers.disable_posts")
         admin_ids = mocker.patch("src.command_handlers.admin_ids", new=["102","103"])
- 
-            
-        await disable_user(mock_update, None)
-        if user_to_disable is None:
-            mock_update.message.reply_text.assert_called_once_with("Please enter a user id")
+
+        await disable_user(mock_update, None)        
+
+        if user_to_disable is None or post_type not in ["sale", "search", None]:
+            mock_update.message.reply_text.assert_called_once_with(INVALID_DISABLE_USER)
             return
         if update_details["chat_type"]!="private":
             mock_update.message.set_reaction.assert_called_once_with("👎")
             return
         if update_details["user_id"] not in admin_ids:
-            mock_update.message.reply_text.assert_called_once_with("Sorry this command is only available to the admin!")
+            mock_update.message.reply_text.assert_called_once_with(INVALID_NOT_AN_ADMIN)
             return
-        mock_disable_posts.assert_called_once_with(user_id=int(user_to_disable))
+        mock_disable_posts.assert_called_once_with(user_to_disable, post_type)
+
+    @pytest.mark.parametrize(["update_details","user_to_disable","game_id", "post_type"],
+                            [
+                                (
+                                    {
+                                        "chat_type":"group", 
+                                        "user_id":"101",
+                                        "text":"/disable_post_for_user 101 312484 sale"
+                                    },
+                                    "101",
+                                    "312484",
+                                    "sale"
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"102",
+                                        "text":"/disable_post_for_user"
+                                     },
+                                    None,
+                                    None,
+                                    None
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"103",
+                                        "text":"/disable_post_for_user 101 312484 sale"
+                                    },
+                                    "101",
+                                    "312484",
+                                    "sale"
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"103",
+                                        "text":"/disable_post_for_user 101 312484 search"
+                                    },
+                                    "101",
+                                    "312484",
+                                    "search"
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"103",
+                                        "text":"/disable_post_for_user 101 312484 gibberish"
+                                    },
+                                    "101",
+                                    "312484",
+                                    "gibberish"
+                                ),
+                                (
+                                    {
+                                        "chat_type":"private", 
+                                        "user_id":"101",
+                                        "text":"/disable_post_for_user 101 312484 sale"
+                                    },
+                                    "101",
+                                    "312484",
+                                    "sale"
+                                )
+                            ],
+                            ids=[
+                                "failed_in_group",
+                                "invalid_message_format",
+                                "successfully_disabled_sale",
+                                "successfully_disabled_search",
+                                "invalid_post_type",
+                                 "non-admin"
+                                 ]
+                            )
+    async def test_disable_post_for_user(self, update_details, user_to_disable, game_id, post_type, mock_update, mocker):
+        """Checks if the right methods are called based on the message input"""
+        mock_update.effective_chat.type=update_details["chat_type"]
+        mock_update.message.from_user.id=update_details["user_id"]
+        mock_update.message.text=update_details["text"]
+
+        mock_disable_posts = mocker.patch("src.command_handlers.disable_posts")
+        admin_ids = mocker.patch("src.command_handlers.admin_ids", new=["102","103"])
+
+        await disable_post_for_user(mock_update, None)        
+
+        if user_to_disable is None or post_type not in ["sale", "search"] or game_id is None:
+            mock_update.message.reply_text.assert_called_once_with(INVALID_DISABLE_POST_FOR_USER)
+            return
+        if update_details["chat_type"]!="private":
+            mock_update.message.set_reaction.assert_called_once_with("👎")
+            return
+        if update_details["user_id"] not in admin_ids:
+            mock_update.message.reply_text.assert_called_once_with(INVALID_NOT_AN_ADMIN)
+            return
+        mock_disable_posts.assert_called_once_with(user_to_disable, post_type, game_id)


### PR DESCRIPTION
- disable_post_for_user added. Allows an admin to disable a specific post for a user based on user id, game id, and post type
- Updated disable_user so that post type must now be one of sale|search|all
- Extracted all bot replies into a constants file for maintainability and testability 

Addresses #75 and #73 