### PR TITLE
Log incoming chat id, type, and title (temporary)

### DIFF
--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -28,6 +28,12 @@ async def message_handler(update: Update, _: ContextTypes.DEFAULT_TYPE, bgg_clie
     :param _:
     :return:
     """
+    log.info(
+        "chat_id=%s type=%s title=%s",
+        update.effective_chat.id,
+        update.effective_chat.type,
+        update.effective_chat.title,
+    )
     # Check if message is a valid command before trying to hit the API
     post_type = find_post_type(update.message)
 


### PR DESCRIPTION
## Summary
- Adds a one-line `log.info` in `message_handler` capturing `chat_id`, `type`, and `title` for every incoming Telegram message.
- Purpose: capture the marketplace group's `chat_id` so an upcoming daily-summary job can post to it. The group ID isn't recoverable from forwarded messages (Telegram strips `forward_from_chat` for groups), so a server-side log is the simplest path.
- Intended to be reverted once the ID has been recorded.

## Test plan
- [ ] Merge and redeploy
- [ ] Wait for any message in the marketplace group
- [ ] `docker compose logs meeple-matchmaker | grep "chat_id=" | grep -v private` → record the `-100…` ID
- [ ] Open a follow-up PR to revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)