### PR TITLE
Fix startup crash: install python-telegram-bot job-queue extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bgg-api==1.1.13
-python-telegram-bot==22.7
+python-telegram-bot[job-queue]==22.7
 peewee==3.17.7
 
 pytest==8.2.1


### PR DESCRIPTION
## Problem

The bot crashes on startup with:

```
AttributeError: 'NoneType' object has no attribute 'run_daily'
  File "/app/./src/bot.py", line 59, in init_app
    app.job_queue.run_daily(callback=cleanup_expired_posts, time=datetime.time())
```

## Root cause

The auto-expiry feature (#77) added `app.job_queue.run_daily(...)` in `bot.py`, but `requirements.txt` pinned `python-telegram-bot==22.7` **without the `[job-queue]` extra**. Without that extra, APScheduler is not installed, so PTB's `Application.job_queue` property returns `None`, and calling `.run_daily()` on it raises `AttributeError`. The `PTBUserWarning` logged just before the crash points to the same fix.

## Fix

```diff
-python-telegram-bot==22.7
+python-telegram-bot[job-queue]==22.7
```

## Verification

- Installed the extra locally (APScheduler 3.11.2); a built `Application` now has a real `JobQueue` and `run_daily` is callable.
- `pytest`: 121 passed, coverage 83%.

> After merge, rebuild the image so deps reinstall: `docker compose up -d --build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)