### PR TITLE
Error Reporter and Group Permissions

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -6,6 +6,7 @@ import logging
 import os
 from boardgamegeek import BGGClient, CacheBackendMemory  # type: ignore
 from telegram.ext import ApplicationBuilder, MessageHandler, CommandHandler
+from src.error_handler import error_handler_cb
 from src.job_queues import (
     cleanup_expired_posts,
     generate_daily_summary,
@@ -58,6 +59,8 @@ def init_app(auth_token):
     message_handler_with_client = init_message_handler()
     # message handlers
     app.add_handler(MessageHandler(filters=None, callback=message_handler_with_client))
+
+    app.add_error_handler(error_handler_cb)
 
     # Run a daily cleanup at midnight in the bots default timezone
     app.job_queue.run_daily(callback=cleanup_expired_posts, time=datetime.time())

--- a/src/constants.py
+++ b/src/constants.py
@@ -11,10 +11,10 @@ ERROR_GROUP_CHAT_ID = -5334001786
 # ERROR_GROUP_CHAT_ID = -1003918412989
 
 ADMIN_IDS = [
-    995823071,   # Sahil Thapar
+    995823071,  # Sahil Thapar
     6946013582,  # Mica
-    635786234,   # Anshul J
-    683593077    # Yash @starscr3am
+    635786234,  # Anshul J
+    683593077,  # Yash @starscr3am
 ]
 
 DAILY_SUMMARY_WINDOW = 2

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,6 +6,10 @@ MEEPLE_MARKET_CHAT_ID = -1001243715567
 # Meeple dev chat id for local dev
 # MEEPLE_MARKET_CHAT_ID = -1003918412989
 
+ERROR_GROUP_CHAT_ID = -5334001786
+# Personal Error group chat id for local dev
+# ERROR_GROUP_CHAT_ID = -1003918412989
+
 ADMIN_IDS = [
     995823071,   # Sahil Thapar
     6946013582,  # Mica

--- a/src/error_handler.py
+++ b/src/error_handler.py
@@ -1,0 +1,38 @@
+import html
+import json
+import logging
+import traceback
+
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+
+from src.constants import ERROR_GROUP_CHAT_ID
+
+log = logging.getLogger("meeple-matchmaker")
+
+async def error_handler_cb(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Log the error and send a telegram message to notify the developer."""
+    # Log the error before we do anything else, so we can see it even if something breaks.
+    log.error("Exception while handling an update:", exc_info=context.error)
+
+    # traceback.format_exception returns the usual python message about an exception, but as a
+    # list of strings rather than a single string, so we have to join them together.
+    tb_list = traceback.format_exception(None, context.error, context.error.__traceback__)
+    tb_string = "".join(tb_list)
+
+    # Build the message with some markup and additional information about what happened.
+    # You might need to add some logic to deal with messages longer than the 4096 character limit.
+    update_str = update.to_dict() if isinstance(update, Update) else str(update)
+    message = (
+        "An exception was raised while handling an update\n"
+        f"<pre>update = {html.escape(json.dumps(update_str, indent=2, ensure_ascii=False))}"
+        "</pre>\n\n"
+        f"<pre>{html.escape(tb_string)}</pre>"
+    )
+
+    log.info(len(message))
+    # Finally, send the message
+    await context.bot.send_message(
+        chat_id=ERROR_GROUP_CHAT_ID, text=message, parse_mode=ParseMode.HTML
+    )

--- a/src/error_handler.py
+++ b/src/error_handler.py
@@ -11,6 +11,7 @@ from src.constants import ERROR_GROUP_CHAT_ID
 
 log = logging.getLogger("meeple-matchmaker")
 
+
 async def error_handler_cb(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Log the error and send a telegram message to notify the developer."""
     # Log the error before we do anything else, so we can see it even if something breaks.
@@ -18,7 +19,9 @@ async def error_handler_cb(update: object, context: ContextTypes.DEFAULT_TYPE) -
 
     # traceback.format_exception returns the usual python message about an exception, but as a
     # list of strings rather than a single string, so we have to join them together.
-    tb_list = traceback.format_exception(None, context.error, context.error.__traceback__)
+    tb_list = traceback.format_exception(
+        None, context.error, context.error.__traceback__
+    )
     tb_string = "".join(tb_list)
 
     # Build the message with some markup and additional information about what happened.

--- a/src/job_queues.py
+++ b/src/job_queues.py
@@ -77,7 +77,9 @@ async def generate_summary(summary_period, context: CallbackContext):
 
     if len(posts) == 0:
         log.info(
-            "No posts to summarize from %s till today - summary window: %d", start_date.strftime("%d/%m/%Y"), summary_period
+            "No posts to summarize from %s till today - summary window: %d",
+            start_date.strftime("%d/%m/%Y"),
+            summary_period,
         )
         return
 

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -12,6 +12,7 @@ from src.telegrampost import (
     parse_message,
     find_post_type,
     is_post_type_banned,
+    is_from_external_chat
 )
 from src.database import read_posts, disable_posts
 from src.models import Post
@@ -49,7 +50,7 @@ async def message_handler(
     if not post_type:
         return
 
-    should_ignore_post = is_post_type_banned(post_type, update.effective_chat.type)
+    should_ignore_post = is_post_type_banned(post_type, update.effective_chat.type) or is_from_external_chat(update.effective_chat.type, update.effective_chat.id)
 
     if should_ignore_post:
         await update.message.set_reaction("👎")

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -12,7 +12,7 @@ from src.telegrampost import (
     parse_message,
     find_post_type,
     is_post_type_banned,
-    is_from_external_chat
+    is_from_external_chat,
 )
 from src.database import read_posts, disable_posts
 from src.models import Post
@@ -50,7 +50,9 @@ async def message_handler(
     if not post_type:
         return
 
-    should_ignore_post = is_post_type_banned(post_type, update.effective_chat.type) or is_from_external_chat(update.effective_chat.type, update.effective_chat.id)
+    should_ignore_post = is_post_type_banned(
+        post_type, update.effective_chat.type
+    ) or is_from_external_chat(update.effective_chat.type, update.effective_chat.id)
 
     if should_ignore_post:
         await update.message.set_reaction("👎")

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -160,13 +160,16 @@ def is_post_type_banned(post_type: str, chat_type: str) -> bool:
     banned_in_group = post_type in POST_TYPES_BANNED_IN_GROUP and chat_type != "private"
     return banned_in_dm or banned_in_group
 
+
 def is_from_external_chat(chat_type, chat_id) -> bool:
     """
     True if someone tries to add meeple bot to another group and send messages from there.
-    We only want messages from meeple market to pass through
+    We only want messages from meeple market to pass through.
     """
-    if chat_type!="private" and chat_id!=MEEPLE_MARKET_CHAT_ID:
+    if chat_type != "private" and chat_id != MEEPLE_MARKET_CHAT_ID:
         return True
+    return False
+
 
 def format_user_tag(username, userid):
     """Helper func that returns a markdown link to a user's profile"""

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 from telegram import Message
 from boardgamegeek import BGGClient, BGGItemNotFoundError  # type: ignore
 
+from src.constants import MEEPLE_MARKET_CHAT_ID
 from src.models import Game, User, Post
 
 log = getLogger()
@@ -159,6 +160,13 @@ def is_post_type_banned(post_type: str, chat_type: str) -> bool:
     banned_in_group = post_type in POST_TYPES_BANNED_IN_GROUP and chat_type != "private"
     return banned_in_dm or banned_in_group
 
+def is_from_external_chat(chat_type, chat_id) -> bool:
+    """
+    True if someone tries to add meeple bot to another group and send messages from there.
+    We only want messages from meeple market to pass through
+    """
+    if chat_type!="private" and chat_id!=MEEPLE_MARKET_CHAT_ID:
+        return True
 
 def format_user_tag(username, userid):
     """Helper func that returns a markdown link to a user's profile"""

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,67 @@
+"""Tests for the Telegram error handler."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from telegram.constants import ParseMode
+
+from src.constants import ERROR_GROUP_CHAT_ID
+from src.error_handler import error_handler_cb
+
+
+class TestErrorHandler:
+    """Covers error reporting behavior for the bot."""
+
+    @pytest.mark.asyncio
+    async def test_error_handler_reports_exception_to_error_group(self, mocker):
+        """The handler should log the failure and forward a report to the error chat."""
+        update = mocker.Mock()
+        update.to_dict.return_value = {"message": {"text": "hello"}}
+        error = None
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as exc:
+            error = exc
+
+        context = mocker.Mock()
+        context.error = error
+        context.bot.send_message = AsyncMock()
+
+        mocked_logger = mocker.patch("src.error_handler.log")
+
+        await error_handler_cb(update, context)
+
+        mocked_logger.error.assert_called_once()
+        mocked_logger.info.assert_called_once()
+        context.bot.send_message.assert_awaited_once()
+        context.bot.send_message.assert_awaited_once_with(
+            chat_id=ERROR_GROUP_CHAT_ID,
+            text=mocker.ANY,
+            parse_mode=ParseMode.HTML,
+        )
+
+        sent_message = context.bot.send_message.await_args.kwargs["text"]
+        assert "An exception was raised while handling an update" in sent_message
+        assert "boom" in sent_message
+        assert "<pre>update =" in sent_message
+
+    @pytest.mark.asyncio
+    async def test_error_handler_handles_non_update_objects(self, mocker):
+        """The handler should still report a string-based update payload safely."""
+        context = mocker.Mock()
+        try:
+            raise ValueError("bad payload")
+        except ValueError as exc:
+            context.error = exc
+        context.bot.send_message = AsyncMock()
+
+        mocked_logger = mocker.patch("src.error_handler.log")
+
+        await error_handler_cb("not-an-update", context)
+
+        mocked_logger.error.assert_called_once()
+        context.bot.send_message.assert_awaited_once()
+
+        sent_message = context.bot.send_message.await_args.kwargs["text"]
+        assert "not-an-update" in sent_message
+        assert "bad payload" in sent_message

--- a/tests/test_job_queues.py
+++ b/tests/test_job_queues.py
@@ -365,9 +365,15 @@ class TestJobQueues:
             ("{text}", "\\{text\\}"),
             ("hello.world", "hello\\.world"),
             ("what!", "what\\!"),
-            ("스플렌더: Pokémon (Splendor: Pokémon)", "스플렌더: Pokémon \\(Splendor: Pokémon\\)"),
+            (
+                "스플렌더: Pokémon (Splendor: Pokémon)",
+                "스플렌더: Pokémon \\(Splendor: Pokémon\\)",
+            ),
             ("a_b*c[d]", "a\\_b\\*c\\[d\\]"),
-            ("all!chars@#$%_*[]()~`>#+-=|{}.!test", "all\\!chars@\\#$%\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!test"),
+            (
+                "all!chars@#$%_*[]()~`>#+-=|{}.!test",
+                "all\\!chars@\\#$%\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!test",
+            ),
         ],
         ids=[
             "no_special_chars",

--- a/tests/test_message_handlers.py
+++ b/tests/test_message_handlers.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 import pytest
 
+from src.constants import MEEPLE_MARKET_CHAT_ID
 from src.message_handlers import message_handler
 from src.models import Post, Game, User
 from tests.helpers import initialize_post
@@ -17,7 +18,7 @@ class TestMessageHandlers:
         mocker.patch("telegram.ext.ContextTypes.DEFAULT_TYPE")
 
     @pytest.mark.parametrize(
-        argnames="init_posts,new_messages,expected_replies,chat_type,expected_reaction",
+        argnames="init_posts,new_messages,expected_replies,chat_type,expected_reaction, chat_id",
         argvalues=[
             # simple scenario with a two sale posts followed by a search post
             (
@@ -51,6 +52,7 @@ class TestMessageHandlers:
                 ["[alpha](tg://user?id=101), [beta](tg://user?id=102)"],
                 "private",
                 "👍",
+                123,
             ),
             # simple scenario with a two search posts followed by a sale post
             (
@@ -82,6 +84,7 @@ class TestMessageHandlers:
                 ["[alpha](tg://user?id=101), [beta](tg://user?id=102)"],
                 "group",
                 "👍",
+                MEEPLE_MARKET_CHAT_ID,
             ),
             # simple scenario with a sale post followed by a sold post
             (
@@ -104,6 +107,7 @@ class TestMessageHandlers:
                 [""],
                 "private",
                 "👍",
+                123,
             ),
             # simple scenario with a search post followed by a found post (private chat)
             (
@@ -126,6 +130,7 @@ class TestMessageHandlers:
                 [""],
                 "private",
                 "👍",
+                123,
             ),
             # simple scenario with a search post followed by a found post (group chat)
             (
@@ -148,6 +153,7 @@ class TestMessageHandlers:
                 [""],
                 "group",
                 "👎",
+                MEEPLE_MARKET_CHAT_ID,
             ),
             # simple scenario with a sale post in private chat
             (
@@ -170,6 +176,30 @@ class TestMessageHandlers:
                 [""],
                 "private",
                 "👎",
+                123,
+            ),
+            # simple scenario with a search post followed by a sell post (in external group chat)
+            (
+                [
+                    (
+                        "sell",
+                        167791,
+                        "#lookingfor terraforming mars",
+                        "101",
+                        "alpha",
+                        1,
+                        "Terraforming Mars",
+                    )
+                ],
+                [
+                    SimpleNamespace(
+                        text="#sell terraforming mars", id=101, first_name="Beta"
+                    )
+                ],
+                [""],
+                "group",
+                "👎",
+                123,
             ),
             # todo: scenario with disable notifications in between
         ],
@@ -180,6 +210,7 @@ class TestMessageHandlers:
             "scenario4-simple-search-followed-by-a-found-private",
             "scenario5-simple-search-followed-by-a-found-group",
             "scenario6-simple-search-followed-by-a-sell-private",
+            "scenario7-simple-search-followed-by-a-sell-external-group",
         ],
     )
     async def test_scenario(
@@ -192,6 +223,7 @@ class TestMessageHandlers:
         expected_replies,
         chat_type,
         expected_reaction,
+        chat_id,
         bgg_client,
     ):
         """Tests multiple scenarios passed to the message handler"""
@@ -220,7 +252,7 @@ class TestMessageHandlers:
             mock_update.message.from_user.id = msg.id
             mock_update.message.from_user.first_name = msg.first_name
             mock_update.effective_chat.type = chat_type
-
+            mock_update.effective_chat.id = chat_id
             await message_handler(mock_update, mock_context, bgg_client)
             if reply:
                 mock_update.message.reply_text.assert_called_once_with(

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -1,6 +1,7 @@
 """Tests all telegram post helper functionality"""
 
 import pytest
+from src.constants import MEEPLE_MARKET_CHAT_ID
 from src.telegrampost import (
     format_user_tag,
     parse_tag,
@@ -11,6 +12,7 @@ from src.telegrampost import (
     get_message_contents,
     get_message_without_command,
     is_post_type_banned,
+    is_from_external_chat,
     find_post_type,
 )
 
@@ -296,6 +298,19 @@ class TestMessageParsing:
     def test_is_post_type_banned(self, post, banned):
         """Test if the function returns the correct boolean for a specific post type"""
         assert is_post_type_banned(post["type"], post["chat_type"]) is banned
+
+    @pytest.mark.parametrize(
+        argnames="chat_type, chat_id, expected",
+        argvalues=[
+            ("private", 123, False),
+            ("group", MEEPLE_MARKET_CHAT_ID, False),
+            ("group", 999, True),
+        ],
+        ids=["private-chat", "meeple-market-group", "external-group"],
+    )
+    def test_is_from_external_chat(self, chat_type, chat_id, expected):
+        """Test whether only non-Meeple-market groups are treated as external."""
+        assert is_from_external_chat(chat_type, chat_id) is expected
 
     @pytest.mark.parametrize(
         argnames="username, user_id, expected",


### PR DESCRIPTION
Linked Issue: #78 

## Error Reporter
Added python-telegram-bot's basic error reporter example to meeple-bot. This will allow meeple bot to send all exceptions to a group I have created.
As a result, debugging issues should become easier for people who don't have access to the logs.

## Group Permissions
People who add meeple bot to a new group will now not be able to interact with it.
Messages that start with a # will not be accepted
/ commands will still be allowed since those are not db altering.

# Screenshots
Error report
<img width="1425" height="1072" alt="image" src="https://github.com/user-attachments/assets/bd374206-7dd5-4179-a0a9-0f6be74d5e18" />

Group Permission
<img width="228" height="102" alt="image" src="https://github.com/user-attachments/assets/1cdb94ea-d3e8-439b-9582-b8f510978dc6" />
