### PR TITLE
Added more exception logging for easier debugging

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -83,7 +83,9 @@ def init_app(auth_token):
 def init_message_handler():
     """Returns the message handler with the bgg_client injected. Allows easier testing"""
     bgg_client = BGGClient(
-        cache=CacheBackendMemory(ttl=3600 * 24 * 7),
+        cache=CacheBackendMemory(ttl=3600 * 24),
+        timeout=30,
+        retries=5,
         access_token=os.getenv("BGG_BEARER"),
     )
 

--- a/src/job_queues.py
+++ b/src/job_queues.py
@@ -85,7 +85,7 @@ async def generate_summary(summary_period, context: CallbackContext):
     final_table = ""
 
     for post in posts:
-        final_table += f"\n{escape_markdown_reserved_chars(post.game.game_name)} by {escape_markdown_reserved_chars(post.user.first_name)}"
+        final_table += f"\n\- *{escape_markdown_reserved_chars(post.game.game_name)}* by {escape_markdown_reserved_chars(post.user.first_name)}"
 
     final_table = get_summary_message_header(summary_period, start_date) + final_table
     await context.bot.send_message(

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -60,11 +60,12 @@ async def message_handler(
 
     log.info("Attempting to parse message")
     post, game, user = (
-        parse_message(update.message, bgg_client)
+        await parse_message(update.message, bgg_client)
         if update.message
         else (None, None, None)
     )
     if not post or not game or not user:
+        await update.message.set_reaction("🤔")
         return
     if update.message:
         if post.post_type == "search" or post.post_type == "sale":

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -1,5 +1,6 @@
 """Module providing miscellaneous processing methods related to telegram posts"""
 
+import asyncio
 import re
 from logging import getLogger
 from typing import Optional, Tuple
@@ -32,6 +33,8 @@ POST_TYPES_BANNED_IN_GROUP = ["found"]
 
 def get_message_contents(message: Message) -> str:
     """Extract the text or caption from a message"""
+    if message is None:
+        return ""
     text = message.text or message.caption
     return text.lower() if text else ""
 
@@ -53,7 +56,7 @@ def parse_game_name(message: str) -> str:
     return first_line.replace("game name:", "").replace("game:", "").strip()
 
 
-def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
+async def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
     """
     Uses the BGG Client to fetch a game based on its name.
     If found, checks the DB for an existing entry, otherwise creates the game and returns the model.
@@ -61,7 +64,7 @@ def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
     try:
         log.info("Trying exact match for game: %s", game_name)
         # todo: use .search instead of .game
-        game_exact = bgg_client.game(game_name, exact=True)
+        game_exact = await asyncio.to_thread(bgg_client.game, game_name, exact=True)
         if game_exact:
             log.info("Found exact match")
             game, _ = Game.get_or_create(
@@ -71,7 +74,9 @@ def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
     except BGGItemNotFoundError:
         try:
             log.info("Failed to find exact match, trying fuzzy match")
-            game_fuzzy = bgg_client.game(game_name, exact=False)
+            game_fuzzy = await asyncio.to_thread(
+                bgg_client.game, game_name, exact=False
+            )
             if game_fuzzy:
                 log.info("Found fuzzy match")
                 game, _ = Game.get_or_create(
@@ -80,7 +85,10 @@ def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
                 return game
         except BGGItemNotFoundError:
             log.warning("Failed to get fuzzy match, no game name found")
-            return
+            return None
+    except Exception as e:
+        raise e
+    return None
 
 
 def create_user_from_message(message: Message) -> User:
@@ -102,7 +110,7 @@ def get_message_without_command(message: Message) -> str:
     return text.split(" ")[1]
 
 
-def parse_message(
+async def parse_message(
     message: Message, bgg_client
 ) -> Tuple[Optional[Post], Optional[Game], Optional[User]]:
     """
@@ -127,7 +135,7 @@ def parse_message(
 
     # parse game info
     game_name = parse_game_name(message_without_tag)
-    game = get_game_details(game_name, bgg_client)
+    game = await get_game_details(game_name, bgg_client)
     if not game:
         log.warning("Game not found")
         return None, None, None

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -175,10 +175,10 @@ class TestMessageParsing:
             "fuzzy-search",
         ],
     )
-    def test_get_game(
+    async def test_get_game(
         self, bgg_client, database, game_name, expected_game_id, expected_game_name
     ):
-        game = get_game_details(game_name, bgg_client)
+        game = await get_game_details(game_name, bgg_client)
         if not expected_game_id:
             assert game is None
         else:
@@ -208,7 +208,7 @@ class TestMessageParsing:
         ],
         ids=["search", "sale", "sale-selling", "no-type", "no-game"],
     )
-    def test_parse_message(
+    async def test_parse_message(
         self,
         mock_message,
         database,
@@ -224,7 +224,7 @@ class TestMessageParsing:
         mock_message.from_user.first_name = str(user_id * 100)
         mock_message.from_user.last_name = str(user_id * 50)
 
-        post, game, user = parse_message(mock_message, bgg_client)
+        post, game, user = await parse_message(mock_message, bgg_client)
 
         if not post:
             assert post == expected_game_id


### PR DESCRIPTION
- Caught exceptions other than BGGItemNotFound to see where the bot is failing
- Reduced cache TTL from 1 week to 1 day
- Handled a case where message is None in get_message_contents. Otherwise, an exception is raised which also pollutes the exception reporting group every time someone edits a message / bids on an auction via commentsbot
- Cleaned up the reporting format so its more readable
- Wrapped the bgg client call in a thread so that it is non-blocking in case of timeouts / retries
- Added 🤔 as a reaction when the bot can't find a game