### PR TITLE
Added message links for easy redirection to sale posts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,5 +18,7 @@ if [ ! -f /app/database/meeple-matchmaker.db ]; then
   echo "Seeding meeple-matchmaker.db into volume..."
   cp /app/seed/meeple-matchmaker.db /app/database/meeple-matchmaker.db
 fi
-
+cd /app/migrations
+python migration_add_telegram_msg_id.py
+cd /app
 exec "$@"

--- a/migrations/migration_add_telegram_msg_id.py
+++ b/migrations/migration_add_telegram_msg_id.py
@@ -1,0 +1,25 @@
+"""
+Migration file to add a new telegram_msg_id column to the user_post table
+Needs to be run from within the same folder as the db
+"""
+import sys
+
+from playhouse.migrate import migrate, SchemaMigrator
+from peewee import BigIntegerField, SqliteDatabase
+
+db = SqliteDatabase("../database/meeple-matchmaker.db")
+if "user_post" in db.get_tables():
+    if "telegram_msg_id" in [col.name for col in db.get_columns("user_post")]:
+        print("telegram_msg_id column already present in user_post table")
+        sys.exit()
+
+migrator = SchemaMigrator.from_database(db)
+
+telegram_msg_id = BigIntegerField(null=True)
+
+with db.atomic():
+    migrate(
+        migrator.add_column('user_post', 'telegram_msg_id', telegram_msg_id)
+    )
+
+print("MIGRATION COMPLETE: telegram_msg_id column added successfully")

--- a/src/bot.py
+++ b/src/bot.py
@@ -83,7 +83,9 @@ def init_app(auth_token):
 def init_message_handler():
     """Returns the message handler with the bgg_client injected. Allows easier testing"""
     bgg_client = BGGClient(
-        cache=CacheBackendMemory(ttl=3600 * 24 * 7),
+        cache=CacheBackendMemory(ttl=3600 * 24),
+        timeout=30,
+        retries=5,
         access_token=os.getenv("BGG_BEARER"),
     )
 

--- a/src/command_handlers.py
+++ b/src/command_handlers.py
@@ -6,12 +6,17 @@ import logging
 import os
 from itertools import chain
 from typing import Iterable, Generator
-from boardgamegeek import BGGClient, CacheBackendMemory, BGGApiError
+from boardgamegeek import BGGClient, CacheBackendMemory
 from boardgamegeek.objects.games import CollectionBoardGame
 from src.constants import ADMIN_IDS
 from src.models import Post, UserCollection, Game
-from src.telegrampost import create_user_from_message, get_message_without_command
-from src.database import disable_posts, read_posts
+from src.telegrampost import (
+    create_user_from_message,
+    form_link_to_post,
+    format_user_tag,
+    get_message_without_command,
+)
+from src.database import disable_posts, get_matching_active_posts, read_posts
 from src.messages import (
     INVALID_DISABLE_POST_FOR_USER,
     INVALID_NOT_AN_ADMIN,
@@ -25,29 +30,24 @@ from src.messages import (
 log = logging.getLogger("meeple-matchmaker")
 
 
-def format_post(post: Post, bgg_client: BGGClient) -> str:
+def format_post(post: Post) -> str:
     """
     Method to format a record for replying on telegram
     :param post:
     :param bgg_client:
     :return:
     """
-    game_id = post.game.game_id
     user_id = post.user.telegram_userid
     user_name = post.user.first_name
     game_name = post.game.game_name
-    if not game_name:
-        log.warning("Game name not found in database, searching BGG")
-        try:
-            # Game name not used, not sure if this block is relevant anymore
-            _ = bgg_client.game(game_id=game_id)
-        except BGGApiError:
-            log.error("game_id: %s", game_id)
-            log.error("BGGAPIError")
 
     # remove _ from game_name
-    game_name = game_name.replace("_", "")
-    return f"{game_name}: [{user_name}](tg://user?id={user_id})"
+    game_name_md = game_name.replace("_", "")
+
+    if post.post_type == "sale" and post.telegram_msg_id:
+        game_name_md = form_link_to_post(post.telegram_msg_id, game_name_md)
+
+    return f"{game_name_md}: {format_user_tag(user_name,user_id)}"
 
 
 def format_list_of_posts(posts: Iterable[Post]) -> Generator[str, None, None]:
@@ -56,10 +56,6 @@ def format_list_of_posts(posts: Iterable[Post]) -> Generator[str, None, None]:
     :param posts:
     :return:
     """
-    bgg_client = BGGClient(
-        cache=CacheBackendMemory(ttl=3600 * 24 * 7),
-        access_token=os.getenv("BGG_BEARER"),
-    )
     active_sales = [x for x in posts if x.post_type == "sale"]
     active_searches = [x for x in posts if x.post_type == "search"]
 
@@ -72,15 +68,12 @@ def format_list_of_posts(posts: Iterable[Post]) -> Generator[str, None, None]:
 
         if active_sales:
             formatted_sales = "\nActive sales:\n" + "\n".join(
-                [
-                    format_post(x, bgg_client)
-                    for x in active_sales[i : min(i + 100, sale_count)]
-                ]
+                [format_post(x) for x in active_sales[i : min(i + 100, sale_count)]]
             )
         if active_searches:
             formatted_searches = "\nActive searches:\n" + "\n".join(
                 [
-                    format_post(x, bgg_client)
+                    format_post(x)
                     for x in active_searches[i : min(i + 100, search_count)]
                 ]
             )
@@ -128,7 +121,7 @@ async def list_all_active_sales(update, _):
     if update.effective_chat.type != "private":
         await update.message.set_reaction("👎")
     else:
-        data = read_posts(post_type="sale")
+        data = get_matching_active_posts(post_type="sale")
         reply = format_list_of_posts(data)
         for part in reply:
             await update.message.reply_text(part, parse_mode="Markdown")
@@ -285,11 +278,11 @@ async def match_me(update, _):
     matched_searches = []
     matched_sales = []
     if user_searches:
-        matched_searches = read_posts(
+        matched_searches = get_matching_active_posts(
             game_id=[search.game.game_id for search in user_searches], post_type="sale"
         )
     if user_sales:
-        matched_sales = read_posts(
+        matched_sales = get_matching_active_posts(
             game_id=[sale.game.game_id for sale in user_sales], post_type="search"
         )
 

--- a/src/command_handlers.py
+++ b/src/command_handlers.py
@@ -16,7 +16,7 @@ from src.telegrampost import (
     format_user_tag,
     get_message_without_command,
 )
-from src.database import disable_posts, get_matching_active_posts, read_posts
+from src.database import disable_posts, read_posts
 from src.messages import (
     INVALID_DISABLE_POST_FOR_USER,
     INVALID_NOT_AN_ADMIN,
@@ -121,7 +121,7 @@ async def list_all_active_sales(update, _):
     if update.effective_chat.type != "private":
         await update.message.set_reaction("👎")
     else:
-        data = get_matching_active_posts(post_type="sale")
+        data = read_posts(post_type="sale")
         reply = format_list_of_posts(data)
         for part in reply:
             await update.message.reply_text(part, parse_mode="Markdown")
@@ -278,11 +278,11 @@ async def match_me(update, _):
     matched_searches = []
     matched_sales = []
     if user_searches:
-        matched_searches = get_matching_active_posts(
+        matched_searches = read_posts(
             game_id=[search.game.game_id for search in user_searches], post_type="sale"
         )
     if user_sales:
-        matched_sales = get_matching_active_posts(
+        matched_sales = read_posts(
             game_id=[sale.game.game_id for sale in user_sales], post_type="search"
         )
 

--- a/src/database.py
+++ b/src/database.py
@@ -62,7 +62,7 @@ def read_posts(
         .join(Game, on=Post.game == Game.id)
         .join(User, on=Post.user == User.id)
         .where(reduce(operator.and_, clauses))
-        .order_by(Post.post_type, Game.game_name, User.first_name, Post.updated_at)
+        .order_by(Post.post_type, Game.game_name, User.first_name, Post.updated_at.desc())
     )
     results = data.execute()
 

--- a/src/database.py
+++ b/src/database.py
@@ -61,10 +61,65 @@ def read_posts(
         .join(Game, on=Post.game == Game.id)
         .join(User, on=Post.user == User.id)
         .where(reduce(operator.and_, clauses))
-        .order_by(Post.post_type, Game.game_name, User.first_name)
+        .order_by(Post.post_type, Game.game_name, User.first_name, Post.updated_at)
         .distinct()
     )
     return data.execute()
+
+
+def get_matching_active_posts(
+    post_type: Optional[str] = None,
+    game_id: Optional[Union[int, list[int]]] = None,
+) -> Iterable[Post]:
+    """
+    Gets matching posts with telegram message id from the database.
+    """
+    clauses = [(Post.active == True)]
+
+    if post_type:
+        clauses.append((Post.post_type == post_type))
+    if game_id:
+        # change to a sub-query
+        if isinstance(game_id, int):
+            game_id = [game_id]
+        games = Game.select().where(Game.game_id << game_id)
+        clauses.append((Post.game.in_(games)))
+
+    data = (
+        Post.select(
+            Post.post_type,
+            Post.user,
+            Post.game,
+            Post.telegram_msg_id,
+            Game.game_id,
+            Game.game_name,
+            User.first_name,
+            User.telegram_userid,
+        )
+        .join(Game, on=Post.game == Game.id)
+        .join(User, on=Post.user == User.id)
+        .where(reduce(operator.and_, clauses))
+        .order_by(Post.post_type, Game.game_name, User.first_name, Post.updated_at)
+    )
+    results = data.execute()
+
+    seen = set()
+    filtered_results = []
+
+    # Deduplicating here because distinct doesn't work when we fetch message ids
+    for matched_post in results:
+        dedupe_key = (
+            matched_post.user.telegram_userid,
+            matched_post.game.game_id,
+            matched_post.post_type,
+        )
+        if dedupe_key in seen:
+            continue
+
+        seen.add(dedupe_key)
+        filtered_results.append(matched_post)
+
+    return filtered_results
 
 
 def disable_posts(

--- a/src/database.py
+++ b/src/database.py
@@ -53,43 +53,6 @@ def read_posts(
             Post.user,
             Post.game,
             Post.active,
-            Game.game_id,
-            Game.game_name,
-            User.first_name,
-            User.telegram_userid,
-        )
-        .join(Game, on=Post.game == Game.id)
-        .join(User, on=Post.user == User.id)
-        .where(reduce(operator.and_, clauses))
-        .order_by(Post.post_type, Game.game_name, User.first_name, Post.updated_at)
-        .distinct()
-    )
-    return data.execute()
-
-
-def get_matching_active_posts(
-    post_type: Optional[str] = None,
-    game_id: Optional[Union[int, list[int]]] = None,
-) -> Iterable[Post]:
-    """
-    Gets matching posts with telegram message id from the database.
-    """
-    clauses = [(Post.active == True)]
-
-    if post_type:
-        clauses.append((Post.post_type == post_type))
-    if game_id:
-        # change to a sub-query
-        if isinstance(game_id, int):
-            game_id = [game_id]
-        games = Game.select().where(Game.game_id << game_id)
-        clauses.append((Post.game.in_(games)))
-
-    data = (
-        Post.select(
-            Post.post_type,
-            Post.user,
-            Post.game,
             Post.telegram_msg_id,
             Game.game_id,
             Game.game_name,
@@ -120,7 +83,6 @@ def get_matching_active_posts(
         filtered_results.append(matched_post)
 
     return filtered_results
-
 
 def disable_posts(
     user_id: int, post_type: Optional[str] = None, game_id: Optional[int] = None

--- a/src/job_queues.py
+++ b/src/job_queues.py
@@ -84,6 +84,7 @@ async def generate_summary(summary_period, context: CallbackContext):
 
     final_table = ""
 
+    # TODO: Add post link here
     for post in posts:
         final_table += f"\n\- *{escape_markdown_reserved_chars(post.game.game_name)}* by {escape_markdown_reserved_chars(post.user.first_name)}"
 

--- a/src/job_queues.py
+++ b/src/job_queues.py
@@ -12,6 +12,7 @@ from src.constants import (
 )
 from src.database import read_posts, update_and_get_stale_posts
 from src.messages import generate_stale_post_message, get_summary_message_header
+from src.telegrampost import form_link_to_post
 
 log = logging.getLogger("meeple-matchmaker")
 
@@ -84,9 +85,11 @@ async def generate_summary(summary_period, context: CallbackContext):
 
     final_table = ""
 
-    # TODO: Add post link here
     for post in posts:
-        final_table += f"\n\- *{escape_markdown_reserved_chars(post.game.game_name)}* by {escape_markdown_reserved_chars(post.user.first_name)}"
+        game_text = escape_markdown_reserved_chars(post.game.game_name)
+        if post.telegram_msg_id:
+            game_text = form_link_to_post(post.telegram_msg_id, game_text)
+        final_table += f"\n\- *{game_text}* by {escape_markdown_reserved_chars(post.user.first_name)}"
 
     final_table = get_summary_message_header(summary_period, start_date) + final_table
     await context.bot.send_message(

--- a/src/job_queues.py
+++ b/src/job_queues.py
@@ -85,7 +85,7 @@ async def generate_summary(summary_period, context: CallbackContext):
     final_table = ""
 
     for post in posts:
-        final_table += f"\n{escape_markdown_reserved_chars(post.game.game_name)} by {escape_markdown_reserved_chars(post.user.first_name)}"
+        final_table += f"\n\- *{escape_markdown_reserved_chars(post.game.game_name)}* by {escape_markdown_reserved_chars(post.user.first_name)}"
 
     final_table = get_summary_message_header(summary_period, start_date) + final_table
     await context.bot.send_message(

--- a/src/job_queues.py
+++ b/src/job_queues.py
@@ -12,7 +12,7 @@ from src.constants import (
 )
 from src.database import read_posts, update_and_get_stale_posts
 from src.messages import generate_stale_post_message, get_summary_message_header
-from src.telegrampost import form_link_to_post
+from src.telegrampost import escape_markdown_reserved_chars, form_link_to_post
 
 log = logging.getLogger("meeple-matchmaker")
 
@@ -96,10 +96,3 @@ async def generate_summary(summary_period, context: CallbackContext):
         chat_id=MEEPLE_MARKET_CHAT_ID, text=final_table, parse_mode="MarkdownV2"
     )
 
-
-def escape_markdown_reserved_chars(text: str) -> str:
-    """Escape characters that are reserved by markdown"""
-    chars_to_escape = "_*[]()~`>#+-=|{}.!"
-    for char in chars_to_escape:
-        text = text.replace(char, f"\\{char}")
-    return text

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -107,7 +107,7 @@ def get_matching_post_message_contents(post: Post):
     """
     contents = format_user_tag(post.user.first_name, post.user.telegram_userid)
     if post.telegram_msg_id and post.post_type == "sale":
-        contents += " -> " + form_link_to_post(post.telegram_msg_id)
+        contents += " " + form_link_to_post(post.telegram_msg_id)
     return contents
 
 

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -60,11 +60,12 @@ async def message_handler(
 
     log.info("Attempting to parse message")
     post, game, user = (
-        parse_message(update.message, bgg_client)
+        await parse_message(update.message, bgg_client)
         if update.message
         else (None, None, None)
     )
     if not post or not game or not user:
+        await update.message.set_reaction("🤔")
         return
     if update.message:
         if post.post_type == "search" or post.post_type == "sale":

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -8,13 +8,14 @@ from telegram import Update
 from boardgamegeek import BGGClient  # type: ignore
 
 from src.telegrampost import (
+    form_link_to_post,
     format_user_tag,
     parse_message,
     find_post_type,
     is_post_type_banned,
     is_from_external_chat,
 )
-from src.database import read_posts, disable_posts
+from src.database import get_matching_active_posts, disable_posts
 from src.models import Post
 
 log = logging.getLogger("meeple-matchmaker")
@@ -86,16 +87,28 @@ def find_matching_posts(post: Post) -> Optional[str]:
     :return:
     """
 
-    post_type = COMPLEMENTARY_POST_TYPE.get(post.post_type)
-    posts = read_posts(game_id=post.game.game_id, post_type=post_type)
-    if posts:
-        return ", ".join(
-            [
-                format_user_tag(post.user.first_name, post.user.telegram_userid)
-                for post in posts
-            ]
-        )
-    return None
+    complementary_post_type = COMPLEMENTARY_POST_TYPE.get(post.post_type)
+    matching_posts = get_matching_active_posts(
+        game_id=post.game.game_id,
+        post_type=complementary_post_type,
+    )
+
+    rendered = [
+        get_matching_post_message_contents(matching_post)
+        for matching_post in matching_posts
+    ]
+    return ", ".join(rendered) or None
+
+
+def get_matching_post_message_contents(post: Post):
+    """
+    Returns a markdown link to the sale post if it exists
+    Else returns a link to the user's profile
+    """
+    contents = format_user_tag(post.user.first_name, post.user.telegram_userid)
+    if post.telegram_msg_id and post.post_type == "sale":
+        contents += " -> " + form_link_to_post(post.telegram_msg_id)
+    return contents
 
 
 def disable_post(post: Post) -> None:

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -15,7 +15,7 @@ from src.telegrampost import (
     is_post_type_banned,
     is_from_external_chat,
 )
-from src.database import get_matching_active_posts, disable_posts
+from src.database import read_posts, disable_posts
 from src.models import Post
 
 log = logging.getLogger("meeple-matchmaker")
@@ -88,7 +88,7 @@ def find_matching_posts(post: Post) -> Optional[str]:
     """
 
     complementary_post_type = COMPLEMENTARY_POST_TYPE.get(post.post_type)
-    matching_posts = get_matching_active_posts(
+    matching_posts = read_posts(
         game_id=post.game.game_id,
         post_type=complementary_post_type,
     )

--- a/src/models.py
+++ b/src/models.py
@@ -1,7 +1,7 @@
 """Module providing ORM models for the entities used in meeple-matchmaker"""
 
 import datetime
-from peewee import SqliteDatabase, Model
+from peewee import BigIntegerField, SqliteDatabase, Model
 from peewee import (
     AutoField,
     IntegerField,
@@ -69,6 +69,8 @@ class Post(Model):
     active = BooleanField(default=True)
     user = ForeignKeyField(User)
     game = ForeignKeyField(Game)
+    # TODO: Add migration script for this
+    telegram_msg_id = BigIntegerField(null=True)
     updated_at = DateTimeField(default=datetime.datetime.utcnow)
 
     class Meta:

--- a/src/models.py
+++ b/src/models.py
@@ -69,7 +69,6 @@ class Post(Model):
     active = BooleanField(default=True)
     user = ForeignKeyField(User)
     game = ForeignKeyField(Game)
-    # TODO: Add migration script for this
     telegram_msg_id = BigIntegerField(null=True)
     updated_at = DateTimeField(default=datetime.datetime.utcnow)
 

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -141,7 +141,12 @@ async def parse_message(
         return None, None, None
 
     post = Post(
-        post_type=message_type, text=message_text, active=1, user=user, game=game
+        post_type=message_type,
+        text=message_text,
+        active=1,
+        user=user,
+        game=game,
+        telegram_msg_id=message.id,
     )
     game.save()
     user.save()
@@ -182,3 +187,10 @@ def is_from_external_chat(chat_type, chat_id) -> bool:
 def format_user_tag(username, userid):
     """Helper func that returns a markdown link to a user's profile"""
     return f"[{username}](tg://user?id={userid})"
+
+
+def form_link_to_post(telegram_msg_id, text="Go To Post"):
+    """Helper func that returns a markdown link to a specific message in meeple market"""
+    # Group Chat IDs start with '-100', but links don't use that
+    chat_id_without_prefix = str(MEEPLE_MARKET_CHAT_ID)[4:]
+    return f"[{text}](tg://privatepost?channel={chat_id_without_prefix}&post={telegram_msg_id})"

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -197,7 +197,7 @@ def escape_markdown_reserved_chars(text: str) -> str:
     return text
 
 
-def form_link_to_post(telegram_msg_id, text="Go To Post"):
+def form_link_to_post(telegram_msg_id, text="(Post)"):
     """Helper func that returns a markdown link to a specific message in meeple market"""
     # Group Chat IDs start with '-100', but links don't use that
     chat_id_without_prefix = str(MEEPLE_MARKET_CHAT_ID)[4:]

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -189,6 +189,14 @@ def format_user_tag(username, userid):
     return f"[{username}](tg://user?id={userid})"
 
 
+def escape_markdown_reserved_chars(text: str) -> str:
+    """Escape characters that are reserved by markdown when rendering bot messages."""
+    chars_to_escape = "_*[]()~`>#+-=|{}.!"
+    for char in chars_to_escape:
+        text = text.replace(char, f"\\{char}")
+    return text
+
+
 def form_link_to_post(telegram_msg_id, text="Go To Post"):
     """Helper func that returns a markdown link to a specific message in meeple market"""
     # Group Chat IDs start with '-100', but links don't use that

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -1,5 +1,6 @@
 """Module providing miscellaneous processing methods related to telegram posts"""
 
+import asyncio
 import re
 from logging import getLogger
 from typing import Optional, Tuple
@@ -32,6 +33,8 @@ POST_TYPES_BANNED_IN_GROUP = ["found"]
 
 def get_message_contents(message: Message) -> str:
     """Extract the text or caption from a message"""
+    if message is None:
+        return ""
     text = message.text or message.caption
     return text.lower() if text else ""
 
@@ -53,7 +56,7 @@ def parse_game_name(message: str) -> str:
     return first_line.replace("game name:", "").replace("game:", "").strip()
 
 
-def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
+async def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
     """
     Uses the BGG Client to fetch a game based on its name.
     If found, checks the DB for an existing entry, otherwise creates the game and returns the model.
@@ -61,7 +64,7 @@ def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
     try:
         log.info("Trying exact match for game: %s", game_name)
         # todo: use .search instead of .game
-        game_exact = bgg_client.game(game_name, exact=True)
+        game_exact = await asyncio.to_thread(bgg_client.game, game_name, exact=True)
         if game_exact:
             log.info("Found exact match")
             game, _ = Game.get_or_create(
@@ -71,7 +74,9 @@ def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
     except BGGItemNotFoundError:
         try:
             log.info("Failed to find exact match, trying fuzzy match")
-            game_fuzzy = bgg_client.game(game_name, exact=False)
+            game_fuzzy = await asyncio.to_thread(
+                bgg_client.game, game_name, exact=False
+            )
             if game_fuzzy:
                 log.info("Found fuzzy match")
                 game, _ = Game.get_or_create(
@@ -80,7 +85,10 @@ def get_game_details(game_name: str, bgg_client: BGGClient) -> Optional[Game]:
                 return game
         except BGGItemNotFoundError:
             log.warning("Failed to get fuzzy match, no game name found")
-            return
+            return None
+    except Exception as e:
+        raise e
+    return None
 
 
 def create_user_from_message(message: Message) -> User:
@@ -102,7 +110,7 @@ def get_message_without_command(message: Message) -> str:
     return text.split(" ")[1]
 
 
-def parse_message(
+async def parse_message(
     message: Message, bgg_client
 ) -> Tuple[Optional[Post], Optional[Game], Optional[User]]:
     """
@@ -127,7 +135,7 @@ def parse_message(
 
     # parse game info
     game_name = parse_game_name(message_without_tag)
-    game = get_game_details(game_name, bgg_client)
+    game = await get_game_details(game_name, bgg_client)
     if not game:
         log.warning("Game not found")
         return None, None, None

--- a/tests/test_command_handlers.py
+++ b/tests/test_command_handlers.py
@@ -123,7 +123,7 @@ class TestCommandHandlers:
             game_id=game_id,
             game_name=game_name,
         )
-        assert format_post(post, bgg_client) == textwrap.dedent(expected_response)
+        assert format_post(post) == textwrap.dedent(expected_response)
 
     @pytest.mark.parametrize("chat_type", ("private", "group"))
     async def test_start_command(self, mock_update, chat_type):
@@ -180,18 +180,19 @@ class TestCommandHandlers:
             ),
         ]
 
-        # Mock read_posts to return test data
-        mock_read_posts = mocker.patch(
-            "src.command_handlers.read_posts", return_value=posts_orm
+        # Mock get_matching_posts to return test data
+        mock_get_matching_active_posts = mocker.patch(
+            "src.command_handlers.get_matching_active_posts", return_value=posts_orm
         )
         await list_all_active_sales(mock_update, None)
         if chat_type != "private":
             mock_update.message.set_reaction.assert_called_once_with("👎")
         else:
-            mock_read_posts.assert_called_once_with(post_type="sale")
+            mock_get_matching_active_posts.assert_called_once_with(post_type="sale")
             mock_update.message.reply_text.assert_called()
 
     @pytest.mark.parametrize("chat_type", ("private", "group"))
+    
     async def test_list_all_active_searches(
         self, mock_update, chat_type, mocker, database
     ):

--- a/tests/test_command_handlers.py
+++ b/tests/test_command_handlers.py
@@ -181,14 +181,14 @@ class TestCommandHandlers:
         ]
 
         # Mock get_matching_posts to return test data
-        mock_get_matching_active_posts = mocker.patch(
-            "src.command_handlers.get_matching_active_posts", return_value=posts_orm
+        mock_read_posts = mocker.patch(
+            "src.command_handlers.read_posts", return_value=posts_orm
         )
         await list_all_active_sales(mock_update, None)
         if chat_type != "private":
             mock_update.message.set_reaction.assert_called_once_with("👎")
         else:
-            mock_get_matching_active_posts.assert_called_once_with(post_type="sale")
+            mock_read_posts.assert_called_once_with(post_type="sale")
             mock_update.message.reply_text.assert_called()
 
     @pytest.mark.parametrize("chat_type", ("private", "group"))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,7 +6,6 @@ from src.database import (
     read_posts,
     disable_posts,
     update_and_get_stale_posts,
-    get_matching_active_posts,
 )
 from src.models import User, Game, Post
 
@@ -297,48 +296,3 @@ class TestDatabase:
 
         old_inactive_sale_updated = Post.get_by_id(old_inactive_sale.id)
         assert old_inactive_sale_updated.active == False
-
-    @pytest.mark.parametrize(
-        argnames="post_type,game_id,expected_data",
-        argvalues=[
-            (
-                "sale",
-                167791,
-                [("sale", 167791, "Jacob", None, "Terraforming Mars")],
-            ),
-            (
-                "search",
-                167791,
-                [("search", 167791, "Henry", None, "Terraforming Mars")],
-            ),
-        ],
-        ids=["sale_tfm_matches", "search_tfm_matches"],
-    )
-    def test_get_matching_active_posts_returns_basic_matches(
-        self, sample_posts, post_type, game_id, expected_data
-    ):
-        """Tests basic matching lookups for active posts."""
-        posts = get_matching_active_posts(post_type=post_type, game_id=game_id)
-        posts = [self._post_model_to_tuple(post) for post in posts]
-
-        assert posts == expected_data
-
-    def test_get_matching_active_posts_dedupes_duplicate_rows_for_same_user_game_and_type(
-        self, sample_posts
-    ):
-        """Tests that duplicate matching rows are deduped by user/game/type."""
-        jacob = User.get(telegram_userid=101)
-        terraform_game = Game.get(game_id=167791)
-
-        Post(
-            post_type="sale",
-            text="#selling terraforming mars again",
-            active=True,
-            user=jacob,
-            game=terraform_game,
-        ).save()
-
-        posts = get_matching_active_posts(post_type="sale", game_id=167791)
-        posts = [self._post_model_to_tuple(post) for post in posts]
-
-        assert posts == [("sale", 167791, "Jacob", None, "Terraforming Mars")]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,6 +6,7 @@ from src.database import (
     read_posts,
     disable_posts,
     update_and_get_stale_posts,
+    get_matching_active_posts,
 )
 from src.models import User, Game, Post
 
@@ -296,3 +297,48 @@ class TestDatabase:
 
         old_inactive_sale_updated = Post.get_by_id(old_inactive_sale.id)
         assert old_inactive_sale_updated.active == False
+
+    @pytest.mark.parametrize(
+        argnames="post_type,game_id,expected_data",
+        argvalues=[
+            (
+                "sale",
+                167791,
+                [("sale", 167791, "Jacob", None, "Terraforming Mars")],
+            ),
+            (
+                "search",
+                167791,
+                [("search", 167791, "Henry", None, "Terraforming Mars")],
+            ),
+        ],
+        ids=["sale_tfm_matches", "search_tfm_matches"],
+    )
+    def test_get_matching_active_posts_returns_basic_matches(
+        self, sample_posts, post_type, game_id, expected_data
+    ):
+        """Tests basic matching lookups for active posts."""
+        posts = get_matching_active_posts(post_type=post_type, game_id=game_id)
+        posts = [self._post_model_to_tuple(post) for post in posts]
+
+        assert posts == expected_data
+
+    def test_get_matching_active_posts_dedupes_duplicate_rows_for_same_user_game_and_type(
+        self, sample_posts
+    ):
+        """Tests that duplicate matching rows are deduped by user/game/type."""
+        jacob = User.get(telegram_userid=101)
+        terraform_game = Game.get(game_id=167791)
+
+        Post(
+            post_type="sale",
+            text="#selling terraforming mars again",
+            active=True,
+            user=jacob,
+            game=terraform_game,
+        ).save()
+
+        posts = get_matching_active_posts(post_type="sale", game_id=167791)
+        posts = [self._post_model_to_tuple(post) for post in posts]
+
+        assert posts == [("sale", 167791, "Jacob", None, "Terraforming Mars")]

--- a/tests/test_job_queues.py
+++ b/tests/test_job_queues.py
@@ -11,7 +11,6 @@ from src.job_queues import (
     generate_daily_summary,
     generate_weekly_summary,
     generate_summary,
-    escape_markdown_reserved_chars,
 )
 from src.models import User, Game, Post
 from src.constants import SALE_EXPIRY_DAYS, DAILY_SUMMARY_WINDOW, WEEKLY_SUMMARY_WINDOW
@@ -348,62 +347,6 @@ class TestJobQueues:
         assert "111" in str(error_call_args[1])  # User ID
         assert "Catan" in str(error_call_args[2])  # Game name
 
-    @pytest.mark.parametrize(
-        "input_text, expected_output",
-        [
-            ("hello", "hello"),
-            ("hello_world", "hello\\_world"),
-            ("*bold*", "\\*bold\\*"),
-            ("[link]", "\\[link\\]"),
-            ("(text)", "\\(text\\)"),
-            ("hello~world", "hello\\~world"),
-            ("`code`", "\\`code\\`"),
-            (">quote", "\\>quote"),
-            ("#hashtag", "\\#hashtag"),
-            ("a+b", "a\\+b"),
-            ("a-b", "a\\-b"),
-            ("a=b", "a\\=b"),
-            ("a|b", "a\\|b"),
-            ("{text}", "\\{text\\}"),
-            ("hello.world", "hello\\.world"),
-            ("what!", "what\\!"),
-            (
-                "스플렌더: Pokémon (Splendor: Pokémon)",
-                "스플렌더: Pokémon \\(Splendor: Pokémon\\)",
-            ),
-            ("a_b*c[d]", "a\\_b\\*c\\[d\\]"),
-            (
-                "all!chars@#$%_*[]()~`>#+-=|{}.!test",
-                "all\\!chars@\\#$%\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!test",
-            ),
-        ],
-        ids=[
-            "no_special_chars",
-            "underscore",
-            "asterisks",
-            "square_brackets",
-            "parentheses",
-            "tilde",
-            "backtick",
-            "greater_than",
-            "hash",
-            "plus",
-            "minus",
-            "equals",
-            "pipe",
-            "curly_braces",
-            "period",
-            "exclamation",
-            "korean_and_parens",
-            "multiple_chars",
-            "all_chars",
-        ],
-    )
-    def test_escape_markdown_reserved_chars(self, input_text, expected_output):
-        """Tests escape_markdown_reserved_chars properly escapes all markdown reserved characters"""
-
-        result = escape_markdown_reserved_chars(input_text)
-        assert result == expected_output
 
     @pytest.mark.asyncio
     async def test_generate_daily_summary(self, database, mock_context, mocker):

--- a/tests/test_message_handlers.py
+++ b/tests/test_message_handlers.py
@@ -40,8 +40,8 @@ class TestMessageHandlers:
         contents = get_matching_post_message_contents(post)
 
         assert contents == (
-            "[alpha](tg://user?id=101) -> "
-            f"[Go To Post](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post=42)"
+            "[alpha](tg://user?id=101) "
+            f"[(Post)](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post=42)"
         )
 
     def test_get_matching_post_message_contents_omits_post_link_for_non_sale_posts(
@@ -87,8 +87,8 @@ class TestMessageHandlers:
         reply = find_matching_posts(search_post)
 
         assert reply == (
-            "[alpha](tg://user?id=101) -> "
-            f"[Go To Post](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post={sale_post.telegram_msg_id})"
+            "[alpha](tg://user?id=101) "
+            f"[(Post)](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post={sale_post.telegram_msg_id})"
         )
 
     @pytest.mark.parametrize(

--- a/tests/test_message_handlers.py
+++ b/tests/test_message_handlers.py
@@ -4,7 +4,11 @@ from types import SimpleNamespace
 import pytest
 
 from src.constants import MEEPLE_MARKET_CHAT_ID
-from src.message_handlers import message_handler
+from src.message_handlers import (
+    find_matching_posts,
+    get_matching_post_message_contents,
+    message_handler,
+)
 from src.models import Post, Game, User
 from tests.helpers import initialize_post
 
@@ -16,6 +20,76 @@ class TestMessageHandlers:
     def mock_context(self, mocker):
         """Fixture to mock a telegram context"""
         mocker.patch("telegram.ext.ContextTypes.DEFAULT_TYPE")
+
+    def test_get_matching_post_message_contents_includes_post_link_for_sale_posts(
+        self, database
+    ):
+        """Sale posts should render a user tag plus a direct link to the post."""
+        post = initialize_post(
+            post_type="sale",
+            text="#sale terraforming mars",
+            active=True,
+            user_id=101,
+            user_name="alpha",
+            game_id=167791,
+            game_name="Terraforming Mars",
+        )
+        post.telegram_msg_id = 42
+        post.save()
+
+        contents = get_matching_post_message_contents(post)
+
+        assert contents == (
+            "[alpha](tg://user?id=101) -> "
+            f"[Go To Post](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post=42)"
+        )
+
+    def test_get_matching_post_message_contents_omits_post_link_for_non_sale_posts(
+        self, database
+    ):
+        """Non-sale posts should only include the user tag."""
+        post = initialize_post(
+            post_type="search",
+            text="#lookingfor terraforming mars",
+            active=True,
+            user_id=102,
+            user_name="beta",
+            game_id=167791,
+            game_name="Terraforming Mars",
+        )
+
+        contents = get_matching_post_message_contents(post)
+
+        assert contents == "[beta](tg://user?id=102)"
+
+    def test_find_matching_posts_renders_matching_active_posts(self, database):
+        """Matching posts should be rendered as a comma-separated list."""
+        game = Game.get_or_create(game_id=167791, game_name="Terraforming Mars")[0]
+        seller = User.get_or_create(telegram_userid=101, first_name="alpha")[0]
+        buyer = User.get_or_create(telegram_userid=202, first_name="beta")[0]
+
+        sale_post = Post.create(
+            post_type="sale",
+            text="#sale terraforming mars",
+            active=True,
+            user=seller,
+            game=game,
+            telegram_msg_id=42,
+        )
+        search_post = Post.create(
+            post_type="search",
+            text="#lookingfor terraforming mars",
+            active=True,
+            user=buyer,
+            game=game,
+        )
+
+        reply = find_matching_posts(search_post)
+
+        assert reply == (
+            "[alpha](tg://user?id=101) -> "
+            f"[Go To Post](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post={sale_post.telegram_msg_id})"
+        )
 
     @pytest.mark.parametrize(
         argnames="init_posts,new_messages,expected_replies,chat_type,expected_reaction, chat_id",

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -4,6 +4,7 @@ import pytest
 from src.constants import MEEPLE_MARKET_CHAT_ID
 from src.telegrampost import (
     format_user_tag,
+    form_link_to_post,
     parse_tag,
     TYPE_LOOKUP,
     parse_game_name,
@@ -319,3 +320,23 @@ class TestMessageParsing:
     def test_format_user_tag(self, username, user_id, expected):
         """Test if the function returns the correct markdown for a given user"""
         assert format_user_tag(username=username, userid=user_id) == expected
+
+    @pytest.mark.parametrize(
+        argnames="telegram_msg_id, link_text, expected",
+        argvalues=[
+            (
+                42,
+                "Go To Post",
+                f"[Go To Post](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post=42)",
+            ),
+            (
+                7,
+                "Open listing",
+                f"[Open listing](tg://privatepost?channel={str(MEEPLE_MARKET_CHAT_ID)[4:]}&post=7)",
+            ),
+        ],
+        ids=["default-text", "custom-text"],
+    )
+    def test_form_link_to_post(self, telegram_msg_id, link_text, expected):
+        """Test if the function returns the correct post link markdown."""
+        assert form_link_to_post(telegram_msg_id, text=link_text) == expected

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -3,6 +3,7 @@
 import pytest
 from src.constants import MEEPLE_MARKET_CHAT_ID
 from src.telegrampost import (
+    escape_markdown_reserved_chars,
     format_user_tag,
     form_link_to_post,
     parse_tag,
@@ -340,3 +341,60 @@ class TestMessageParsing:
     def test_form_link_to_post(self, telegram_msg_id, link_text, expected):
         """Test if the function returns the correct post link markdown."""
         assert form_link_to_post(telegram_msg_id, text=link_text) == expected
+
+    @pytest.mark.parametrize(
+        "input_text, expected_output",
+        [
+            ("hello", "hello"),
+            ("hello_world", "hello\\_world"),
+            ("*bold*", "\\*bold\\*"),
+            ("[link]", "\\[link\\]"),
+            ("(text)", "\\(text\\)"),
+            ("hello~world", "hello\\~world"),
+            ("`code`", "\\`code\\`"),
+            (">quote", "\\>quote"),
+            ("#hashtag", "\\#hashtag"),
+            ("a+b", "a\\+b"),
+            ("a-b", "a\\-b"),
+            ("a=b", "a\\=b"),
+            ("a|b", "a\\|b"),
+            ("{text}", "\\{text\\}"),
+            ("hello.world", "hello\\.world"),
+            ("what!", "what\\!"),
+            (
+                "스플렌더: Pokémon (Splendor: Pokémon)",
+                "스플렌더: Pokémon \\(Splendor: Pokémon\\)",
+            ),
+            ("a_b*c[d]", "a\\_b\\*c\\[d\\]"),
+            (
+                "all!chars@#$%_*[]()~`>#+-=|{}.!test",
+                "all\\!chars@\\#$%\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!test",
+            ),
+        ],
+        ids=[
+            "no_special_chars",
+            "underscore",
+            "asterisks",
+            "square_brackets",
+            "parentheses",
+            "tilde",
+            "backtick",
+            "greater_than",
+            "hash",
+            "plus",
+            "minus",
+            "equals",
+            "pipe",
+            "curly_braces",
+            "period",
+            "exclamation",
+            "korean_and_parens",
+            "multiple_chars",
+            "all_chars",
+        ],
+    )
+    def test_escape_markdown_reserved_chars(self, input_text, expected_output):
+        """Tests escape_markdown_reserved_chars properly escapes all markdown reserved characters"""
+
+        result = escape_markdown_reserved_chars(input_text)
+        assert result == expected_output

--- a/tests/test_post.py
+++ b/tests/test_post.py
@@ -175,10 +175,10 @@ class TestMessageParsing:
             "fuzzy-search",
         ],
     )
-    def test_get_game(
+    async def test_get_game(
         self, bgg_client, database, game_name, expected_game_id, expected_game_name
     ):
-        game = get_game_details(game_name, bgg_client)
+        game = await get_game_details(game_name, bgg_client)
         if not expected_game_id:
             assert game is None
         else:
@@ -208,7 +208,7 @@ class TestMessageParsing:
         ],
         ids=["search", "sale", "sale-selling", "no-type", "no-game"],
     )
-    def test_parse_message(
+    async def test_parse_message(
         self,
         mock_message,
         database,
@@ -224,7 +224,7 @@ class TestMessageParsing:
         mock_message.from_user.first_name = str(user_id * 100)
         mock_message.from_user.last_name = str(user_id * 50)
 
-        post, game, user = parse_message(mock_message, bgg_client)
+        post, game, user = await parse_message(mock_message, bgg_client)
 
         if not post:
             assert post == expected_game_id


### PR DESCRIPTION
Targets Issue #67 

## Migration
Added a database migration script that is idempotent. Runs once at build via entrypoint.sh, then on future runs it detects the column and exits early

## Features
- Added message links to all funcs that return "sale" posts. This way any time a sale post is mentioned by the bot, a link to the actual post is also provided. 
- /match_me, /list_all_sales, daily/weekly summaries, and #lookingfor all return these links if available.
- In case of existing data, the message_id is stored as null and checked at render time - returning the user id like it did before
- Added manual deduplication in the database function read_posts instead of relying on `distinct`. This allows us to fetch other details that would cause distinct to fail, like ids.
- Removed stale bgg_client usage in command_handler
- Added helper functions for easier message rendering. Utilised them across the repo for DRY

<img width="620" height="250" alt="image" src="https://github.com/user-attachments/assets/74adbf7f-222f-4fbf-825a-a13bfd29a109" />
<img width="540" height="178" alt="image" src="https://github.com/user-attachments/assets/6c22018b-6a8b-40d1-976e-881b6f83cf84" />
