### PR TITLE
Added an admin command to extract terminal logs for easier debugging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ __pycache__/
 /database/test.db
 /test.db
 /debug/
-
+*.log
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,8 @@ COPY database/meeple-matchmaker.db /app/seed/meeple-matchmaker.db
 # Copy the entrypoint script
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
-
 RUN chmod a+rw /app/database /app/database/* || true
+RUN mkdir -p /app/log && chown -R appuser:appuser /app/log
 
 
 # Switch to the non-privileged user to run the application.

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,7 @@ services:
       - 8081:8081
     volumes:
       - sqlite-data:/app/database
+      - logs:/app/log
     logging:
       driver: "json-file"
       options:
@@ -15,3 +16,4 @@ services:
         max-file: "5"
 volumes:
   sqlite-data:
+  logs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,16 @@ if [ ! -f /app/database/meeple-matchmaker.db ]; then
   echo "Seeding meeple-matchmaker.db into volume..."
   cp /app/seed/meeple-matchmaker.db /app/database/meeple-matchmaker.db
 fi
+
+LOG_DIR=/app/log
+LOG_FILE=$LOG_DIR/bot_logging.log
+
+if [ ! -f "$LOG_FILE" ]; then
+  echo "Creating log file for the first time"
+  touch "$LOG_FILE"
+  chmod a+rw "$LOG_FILE"
+fi
+
 cd /app/migrations
 python migration_add_telegram_msg_id.py
 cd /app

--- a/src/bot.py
+++ b/src/bot.py
@@ -14,6 +14,7 @@ from src.job_queues import (
 )
 from src.message_handlers import message_handler
 from src.command_handlers import (
+    get_logs,
     start_command,
     disable_command,
     list_all_active_sales,
@@ -28,9 +29,16 @@ from src.command_handlers import (
 from src.models import db
 from src.database import init_tables
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler("./log/bot_logging.log", mode="a", encoding="utf-8"),
+        logging.StreamHandler(),
+    ],
+)
 logging.getLogger("httpx").setLevel(logging.WARNING)
-log = logging.getLogger("meeple-matchmaker")
+log = logging.getLogger(__name__)
 
 
 def init_app(auth_token):
@@ -54,6 +62,7 @@ def init_app(auth_token):
         CommandHandler("import_my_bgg_collection", import_my_bgg_collection)
     )
     app.add_handler(CommandHandler("match_me", match_me))
+    app.add_handler(CommandHandler("get_logs", get_logs))
 
     # Generate the message handler with the bgg client so bgg_client doesn't get re-initialised on each message
     message_handler_with_client = init_message_handler()

--- a/src/command_handlers.py
+++ b/src/command_handlers.py
@@ -8,6 +8,7 @@ from itertools import chain
 from typing import Iterable, Generator
 from boardgamegeek import BGGClient, CacheBackendMemory
 from boardgamegeek.objects.games import CollectionBoardGame
+from telegram import Update
 from src.constants import ADMIN_IDS
 from src.models import Post, UserCollection, Game
 from src.telegrampost import (
@@ -27,7 +28,7 @@ from src.messages import (
     MEEPLE_MATCHMAKER_START,
 )
 
-log = logging.getLogger("meeple-matchmaker")
+log = logging.getLogger(__name__)
 
 
 def format_post(post: Post) -> str:
@@ -346,3 +347,28 @@ async def disable_post_for_user(update, _):
         await update.message.set_reaction("👍")
     except IndexError:
         await update.message.reply_text(INVALID_DISABLE_POST_FOR_USER)
+
+async def get_logs(update:Update, context):
+    """Fetch the log file
+    Must be requested by an admin only
+    """
+    if update.effective_chat.type != "private":
+        await update.message.set_reaction("👎")
+        return
+    if update.message.from_user.id not in ADMIN_IDS:
+        await update.message.reply_text(INVALID_NOT_AN_ADMIN)
+        return
+    log_file_path = "./log/bot_logging.log"
+
+    if os.path.exists(log_file_path):
+        # Send the file to the admin
+        log.info("Sending logs to user %s", update.message.from_user.full_name)
+        with open(log_file_path, 'rb') as document:
+            await context.bot.send_document(
+                chat_id=update.message.from_user.id, 
+                document=document, 
+                filename="bot_export.log",
+                caption="Here are your latest bot logs."
+            )
+    else:
+        await update.message.reply_text("Log file not found yet.")

--- a/src/constants.py
+++ b/src/constants.py
@@ -15,6 +15,7 @@ ADMIN_IDS = [
     6946013582,  # Mica
     635786234,  # Anshul J
     683593077,  # Yash @starscr3am
+    1294547458, # Prithvi K
 ]
 
 DAILY_SUMMARY_WINDOW = 2

--- a/src/error_handler.py
+++ b/src/error_handler.py
@@ -9,7 +9,7 @@ from telegram.ext import ContextTypes
 
 from src.constants import ERROR_GROUP_CHAT_ID
 
-log = logging.getLogger("meeple-matchmaker")
+log = logging.getLogger(__name__)
 
 
 async def error_handler_cb(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -23,7 +23,11 @@ async def error_handler_cb(update: object, context: ContextTypes.DEFAULT_TYPE) -
         None, context.error, context.error.__traceback__
     )
     tb_string = "".join(tb_list)
-
+    tb_arr = []
+    if len(tb_string) > 3000:
+        tb_arr = [tb_string[x:3000+x] for x in range(0,len(tb_string),3000)]
+    else:
+        tb_arr = [tb_string]
     # Build the message with some markup and additional information about what happened.
     # You might need to add some logic to deal with messages longer than the 4096 character limit.
     update_str = update.to_dict() if isinstance(update, Update) else str(update)
@@ -31,11 +35,14 @@ async def error_handler_cb(update: object, context: ContextTypes.DEFAULT_TYPE) -
         "An exception was raised while handling an update\n"
         f"<pre>update = {html.escape(json.dumps(update_str, indent=2, ensure_ascii=False))}"
         "</pre>\n\n"
-        f"<pre>{html.escape(tb_string)}</pre>"
     )
 
     log.info(len(message))
     # Finally, send the message
     await context.bot.send_message(
         chat_id=ERROR_GROUP_CHAT_ID, text=message, parse_mode=ParseMode.HTML
+    )
+    for tb in tb_arr:
+        await context.bot.send_message(
+        chat_id=ERROR_GROUP_CHAT_ID, text=f"<pre>{html.escape(tb)}</pre>", parse_mode=ParseMode.HTML
     )

--- a/src/job_queues.py
+++ b/src/job_queues.py
@@ -14,7 +14,7 @@ from src.database import read_posts, update_and_get_stale_posts
 from src.messages import generate_stale_post_message, get_summary_message_header
 from src.telegrampost import escape_markdown_reserved_chars, form_link_to_post
 
-log = logging.getLogger("meeple-matchmaker")
+log = logging.getLogger(__name__)
 
 
 async def cleanup_expired_posts(context):

--- a/src/message_handlers.py
+++ b/src/message_handlers.py
@@ -18,7 +18,7 @@ from src.telegrampost import (
 from src.database import read_posts, disable_posts
 from src.models import Post
 
-log = logging.getLogger("meeple-matchmaker")
+log = logging.getLogger(__name__)
 
 
 COMPLEMENTARY_POST_TYPE = {

--- a/src/telegrampost.py
+++ b/src/telegrampost.py
@@ -11,7 +11,7 @@ from boardgamegeek import BGGClient, BGGItemNotFoundError  # type: ignore
 from src.constants import MEEPLE_MARKET_CHAT_ID
 from src.models import Game, User, Post
 
-log = getLogger()
+log = getLogger(__name__)
 
 
 TYPE_LOOKUP = {

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -15,8 +15,16 @@ class TestErrorHandler:
     @pytest.mark.asyncio
     async def test_error_handler_reports_exception_to_error_group(self, mocker):
         """The handler should log the failure and forward a report to the error chat."""
-        update = mocker.Mock()
-        update.to_dict.return_value = {"message": {"text": "hello"}}
+        class FakeUpdate:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def to_dict(self):
+                return self._payload
+
+        mocker.patch("src.error_handler.Update", FakeUpdate)
+
+        update = FakeUpdate({"message": {"text": "hello"}})
         error = None
         try:
             raise RuntimeError("boom")
@@ -33,17 +41,20 @@ class TestErrorHandler:
 
         mocked_logger.error.assert_called_once()
         mocked_logger.info.assert_called_once()
-        context.bot.send_message.assert_awaited_once()
-        context.bot.send_message.assert_awaited_once_with(
-            chat_id=ERROR_GROUP_CHAT_ID,
-            text=mocker.ANY,
-            parse_mode=ParseMode.HTML,
-        )
+        assert context.bot.send_message.await_count == 2
 
-        sent_message = context.bot.send_message.await_args.kwargs["text"]
-        assert "An exception was raised while handling an update" in sent_message
-        assert "boom" in sent_message
-        assert "<pre>update =" in sent_message
+        first_call, second_call = context.bot.send_message.await_args_list
+
+        assert first_call.kwargs["chat_id"] == ERROR_GROUP_CHAT_ID
+        assert first_call.kwargs["parse_mode"] == ParseMode.HTML
+        assert "An exception was raised while handling an update" in first_call.kwargs["text"]
+        assert "<pre>update =" in first_call.kwargs["text"]
+        assert "hello" in first_call.kwargs["text"]
+
+        assert second_call.kwargs["chat_id"] == ERROR_GROUP_CHAT_ID
+        assert second_call.kwargs["parse_mode"] == ParseMode.HTML
+        assert "<pre>" in second_call.kwargs["text"]
+        assert "RuntimeError: boom" in second_call.kwargs["text"]
 
     @pytest.mark.asyncio
     async def test_error_handler_handles_non_update_objects(self, mocker):
@@ -60,8 +71,9 @@ class TestErrorHandler:
         await error_handler_cb("not-an-update", context)
 
         mocked_logger.error.assert_called_once()
-        context.bot.send_message.assert_awaited_once()
+        assert context.bot.send_message.await_count == 2
 
-        sent_message = context.bot.send_message.await_args.kwargs["text"]
-        assert "not-an-update" in sent_message
-        assert "bad payload" in sent_message
+        first_call, second_call = context.bot.send_message.await_args_list
+        assert "not-an-update" in first_call.kwargs["text"]
+        assert second_call.kwargs["parse_mode"] == ParseMode.HTML
+        assert "ValueError: bad payload" in second_call.kwargs["text"]


### PR DESCRIPTION
- Added a volume pointing to a /log directory. This will persist a bot_logging.log file
- All logger logs are dumped into bot_logging.log
- Updated logger names to be module scoped
- Updated the exception handler to break messages up if they cross 3000 chars. Telegram limits at 4096.
- Added Prithvi K to admin list